### PR TITLE
use List::Util instead of List::MoreUtils for `none`

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -30,7 +30,6 @@ requires:
   DateTime: 0
   Error::Pure: 0.15
   Exporter: 0
-  List::MoreUtils: 0
   List::Util: 1.33
   Mo: 0
   Mo::utils: 0.14

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,6 @@ requires 'Error::Pure' => 0.15;
 requires 'Exporter' => 0;
 requires 'Mo' => 0;
 requires 'Mo::utils' => 0.14;
-requires 'List::MoreUtils' => 0;
 requires 'List::Util' => 1.33;
 requires 'Readonly' => 0;
 requires 'Unicode::UTF8' => 0;

--- a/lib/Wikibase/Datatype/MediainfoSnak.pm
+++ b/lib/Wikibase/Datatype/MediainfoSnak.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Error::Pure qw(err);
-use List::MoreUtils qw(none);
+use List::Util qw(none);
 use Mo qw(build is);
 use Mo::utils qw(check_isa check_required);
 use Readonly;
@@ -193,7 +193,7 @@ Returns string.
 =head1 DEPENDENCIES
 
 L<Error::Pure>,
-L<List::MoreUtils>,
+L<List::Util>,
 L<Mo>,
 L<Mo::utils>,
 L<Readonly>,

--- a/lib/Wikibase/Datatype/MediainfoStatement.pm
+++ b/lib/Wikibase/Datatype/MediainfoStatement.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Error::Pure qw(err);
-use List::MoreUtils qw(none);
+use List::Util qw(none);
 use Mo qw(build default is);
 use Mo::utils qw(check_array_object check_isa check_required);
 use Readonly;
@@ -272,7 +272,7 @@ Returns Wikibase::Datatype::MediainfoSnak instance.
 =head1 DEPENDENCIES
 
 L<Error::Pure>,
-L<List::MoreUtils>,
+L<List::Util>,
 L<Mo>,
 L<Mo::utils>.
 L<Readonly>.

--- a/lib/Wikibase/Datatype/Snak.pm
+++ b/lib/Wikibase/Datatype/Snak.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Error::Pure qw(err);
-use List::MoreUtils qw(none);
+use List::Util qw(none);
 use Mo qw(build is);
 use Mo::utils qw(check_isa check_required);
 use Readonly;
@@ -260,7 +260,7 @@ Returns string.
 =head1 DEPENDENCIES
 
 L<Error::Pure>,
-L<List::MoreUtils>,
+L<List::Util>,
 L<Mo>,
 L<Mo::utils>,
 L<Readonly>,

--- a/lib/Wikibase/Datatype/Statement.pm
+++ b/lib/Wikibase/Datatype/Statement.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Error::Pure qw(err);
-use List::MoreUtils qw(none);
+use List::Util qw(none);
 use Mo qw(build default is);
 use Mo::utils qw(check_array_object check_isa check_required);
 use Readonly;
@@ -289,7 +289,7 @@ Returns Wikibase::Datatype::Snak instance.
 =head1 DEPENDENCIES
 
 L<Error::Pure>,
-L<List::MoreUtils>,
+L<List::Util>,
 L<Mo>,
 L<Mo::utils>.
 L<Readonly>.


### PR DESCRIPTION
Suggestion: use List::Util for `none` instead of `List::MoreUtils`.  The former being bundled with Perl and it looks like it is already being used in other modules for this dist.